### PR TITLE
docs say “exist.jnlp”, not “index.jnlp”

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -8,7 +8,7 @@ declare variable $exist:root external;
 
 if ( $exist:path eq "/") then
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-        <redirect url="index.jnlp"/>
+        <redirect url="exist.jnlp"/>
     </dispatch>
     
 else if( ends-with($exist:resource , ".jnlp")) then


### PR DESCRIPTION
I noticed when clicking on the app in the Dashboard that the downloaded file was called "index.jnlp", but the README said it would be called "exist.jnlp". Obviously the controller as currently coded would let us request "dannes.jnlp"... ;)